### PR TITLE
Add Excel export option

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,9 +146,11 @@
         </section>
 
         <button id="save" data-i18n="save">Guardar</button>
+        <button id="exportExcel" data-i18n="exportExcel">Exportar a Excel</button>
         <footer data-i18n="footer">Datos almacenados en localStorage del navegador</footer>
     </div>
 
+    <script src="https://cdn.sheetjs.com/xlsx-0.19.2/package/dist/xlsx.full.min.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -160,6 +160,14 @@ button {
     width: 100%;
 }
 
+#exportExcel {
+    background: #28a745;
+    color: #fff;
+    padding: 12px 0;
+    width: 100%;
+    margin-top: 10px;
+}
+
 #save:hover {
     background: #0056b3;
 }
@@ -170,6 +178,18 @@ body.dark #save {
 
 body.dark #save:hover {
     background: #00408d;
+}
+
+#exportExcel:hover {
+    background: #1e7e34;
+}
+
+body.dark #exportExcel {
+    background: #1e7e34;
+}
+
+body.dark #exportExcel:hover {
+    background: #155d27;
 }
 
 footer {


### PR DESCRIPTION
## Summary
- add "Exportar a Excel" button
- style the new button in green
- include SheetJS CDN
- implement computeProfit and generateExcel helpers
- export data from all tabs as a multi-sheet XLSX
- add translations for the new button

## Testing
- `node -e "require('./script.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68861985ac248320a2f0f84f9509de80