### PR TITLE
Add branding and remove floor plan field

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
     <div class="container">
         <header>
-            <h1 data-i18n="title">Gestión de Propiedades</h1>
+            <h1><span class="brand">MIMOSAPE</span> <span data-i18n="title">Gestión de Propiedades</span></h1>
             <div class="controls">
                 <select id="language">
                     <option value="es">ES</option>
@@ -43,7 +43,6 @@
             <label data-i18n="purchasePrice">Precio de Compra<input type="number" id="purchasePrice"></label>
             <label data-i18n="rooms">Número de Habitaciones<input type="number" id="rooms"></label>
             <label data-i18n="description">Descripción<textarea id="description"></textarea></label>
-            <label data-i18n="floorPlan">Plano (URL de la imagen)<input type="text" id="floorPlan"></label>
             <label data-i18n="observations">ITE/Observaciones<textarea id="observations"></textarea></label>
         </section>
 

--- a/script.js
+++ b/script.js
@@ -29,7 +29,6 @@ const translations = {
         purchasePrice: 'Precio de Compra',
         rooms: 'Número de Habitaciones',
         description: 'Descripción',
-        floorPlan: 'Plano (URL de la imagen)',
         observations: 'ITE/Observaciones',
         contractSection: 'Contrato de Alquiler',
         tenantName: 'Inquilino',
@@ -104,7 +103,6 @@ const translations = {
         purchasePrice: 'Purchase Price',
         rooms: 'Rooms',
         description: 'Description',
-        floorPlan: 'Floor Plan (image URL)',
         observations: 'ITE/Observations',
         contractSection: 'Rental Contract',
         tenantName: 'Tenant',
@@ -204,7 +202,6 @@ function fillForm(data) {
     document.getElementById('purchasePrice').value = data.general.purchasePrice || '';
     document.getElementById('rooms').value = data.general.rooms || '';
     document.getElementById('description').value = data.general.description || '';
-    document.getElementById('floorPlan').value = data.general.floorPlan || '';
     document.getElementById('observations').value = data.general.observations || '';
 
     const c = data.contract;
@@ -271,7 +268,6 @@ function grabForm() {
             purchasePrice: parseFloat(document.getElementById('purchasePrice').value) || 0,
             rooms: document.getElementById('rooms').value,
             description: document.getElementById('description').value,
-            floorPlan: document.getElementById('floorPlan').value,
             observations: document.getElementById('observations').value,
         },
         contract: {
@@ -372,7 +368,6 @@ function generateExcel(data) {
         ['Precio de Compra', data.general.purchasePrice],
         ['Número de Habitaciones', data.general.rooms],
         ['Descripción', data.general.description],
-        ['Plano', data.general.floorPlan],
         ['ITE/Observaciones', data.general.observations],
     ]);
     XLSX.utils.book_append_sheet(wb, generalSheet, 'Generales');

--- a/style.css
+++ b/style.css
@@ -37,6 +37,13 @@ header h1 {
     margin: 0 0 10px 0;
 }
 
+.brand {
+    color: blue;
+    font-family: 'Arial Black', Arial, sans-serif;
+    text-transform: uppercase;
+    margin-right: 10px;
+}
+
 .controls {
     position: absolute;
     top: 0;


### PR DESCRIPTION
## Summary
- show **MIMOSAPE** brand next to the header
- style brand with blue Arial Black uppercase
- remove the Floor Plan field and translations

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68868081021c832086e0f59687728566