### PR TITLE
Add photo upload support

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,6 +148,9 @@
 
         <button id="save" data-i18n="save">Guardar</button>
         <button id="exportExcel" data-i18n="exportExcel">Exportar a Excel</button>
+        <button id="uploadPhotos" data-i18n="uploadPhotos">Subir Fotos</button>
+        <input type="file" id="photoInput" accept="image/*" multiple style="display:none">
+        <div id="photos"></div>
         <footer data-i18n="footer">Datos almacenados en localStorage del navegador</footer>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -199,6 +199,28 @@ body.dark #exportExcel:hover {
     background: #155d27;
 }
 
+#uploadPhotos {
+    background: #6c757d;
+    color: #fff;
+    padding: 12px 0;
+    width: 100%;
+    margin-top: 10px;
+}
+
+#photos {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 20px;
+    flex-wrap: wrap;
+}
+
+#photos img {
+    width: 300px;
+    border-radius: 8px;
+    object-fit: cover;
+}
+
 footer {
     text-align: center;
     font-size: 12px;


### PR DESCRIPTION
## Summary
- enable adding two photos per property and store them in localStorage
- show photos and button at bottom of the page
- translate new button text
- style the photo area
- increase image size and center gallery

## Testing
- `node --version`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688cadb10ea08320a3c8c0519e909769